### PR TITLE
add --allow-external and process requirements.local last

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -29,24 +29,25 @@ else
     sed -i "s/\$APP/$PYPIAPP/" requirements*
 fi
 
-if [ -f requirements.local.$APP ]; then
-  # uninstall packages before installing them 
-  puts-step "Uninstalling pre-installed shrebo libraries from requirements.local.$APP"
-  /app/.heroku/python/bin/pip uninstall -y -r requirements.local.$APP --disable-pip-version-check
-  puts-step "Installing shrebo packages for $APP from requirements.local.$APP"
-  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local.$APP --allow-external --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
-  PIP_STATUS="${PIPESTATUS[0]}"
-elif [ -f requirements.local ]; then
-  puts-step "Uninstalling pre-installed shrebo libraries from requirements.local"
-  /app/.heroku/python/bin/pip uninstall -y -r requirements.local --disable-pip-version-check
-  puts-step "Installing shrebo packages for $APP from requirements.local"
-  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local --allow-external --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
-  PIP_STATUS="${PIPESTATUS[0]}"
-fi
-
 puts-step "Installing standard packages for $APP"
 /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.txt --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
 PIP_STATUS="${PIPESTATUS[0]}"
+
+# install $APP-local requirements.
+function install_local() {
+  # uninstall packages before installing them 
+  puts-step "Uninstalling pre-installed shrebo libraries from $1"
+  /app/.heroku/python/bin/pip uninstall -y -r $1 --disable-pip-version-check
+  puts-step "Installing shrebo packages for $APP from $"
+  /app/.heroku/python/bin/pip install --process-dependency-links -r $1 --allow-external --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
+  PIP_STATUS="${PIPESTATUS[0]}"
+}
+
+if [ -f requirements.local.$APP ]; then
+  install_local requirements.local.$APP
+elif [ -f requirements.local ]; then
+  install_local requirements.local
+fi
 set -e
 
 show-warnings

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -34,13 +34,13 @@ if [ -f requirements.local.$APP ]; then
   puts-step "Uninstalling pre-installed shrebo libraries from requirements.local.$APP"
   /app/.heroku/python/bin/pip uninstall -y -r requirements.local.$APP --disable-pip-version-check
   puts-step "Installing shrebo packages for $APP from requirements.local.$APP"
-  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local.$APP --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
+  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local.$APP --allow-external --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
   PIP_STATUS="${PIPESTATUS[0]}"
 elif [ -f requirements.local ]; then
   puts-step "Uninstalling pre-installed shrebo libraries from requirements.local"
   /app/.heroku/python/bin/pip uninstall -y -r requirements.local --disable-pip-version-check
   puts-step "Installing shrebo packages for $APP from requirements.local"
-  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
+  /app/.heroku/python/bin/pip install --process-dependency-links -r requirements.local --allow-external --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
   PIP_STATUS="${PIPESTATUS[0]}"
 fi
 


### PR DESCRIPTION
- without `--allow-external`, `--process-dependency-links` wouldn't find github-hosted packages
- if requirements.local is processed first there can be conflicts in overriding or providing a dependency in requirements.extra  *)
- deduplicate the code around installing `requirements.local` or `requirements.local.$APP`

*) Rationale: e.g. a package in requirements.local requests "abc>=1.0.3" and fetches `abc==2.0`, however requirements.extra specifies `abc==1.2`, at the time requirements.extra is processed it would ignore `abc==1.2`. a similar case ensues when requirements.local requests a package that itself does not know to fetch in the particular version it requests, e.g. because the dependency link is wrong, where however a requirements.extra installation is provided
